### PR TITLE
Set tags on aws_ecs_cluster resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ locals {
 
 resource "aws_ecs_cluster" "default" {
   name = var.name
+  tags = var.tags
 }
 
 resource "aws_launch_configuration" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -75,7 +75,7 @@ variable "ssh_cidr_blocks" {
 }
 
 variable "tags" {
-  description = "A mapping of tags to assign to all resources that support tagging"
+  description = "Map of tags for resources where supported"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
This module accepts tags from the caller, but the `aws_ecs_cluster` resource did not accept them. It now does, so we add tags to cluster resources built via this module.