### PR TITLE
Fix bug affecting vpc_id and subnet_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   ec2        = var.enable_ec2_container_instances
-  subnet_ids = flatten([for v in module.get-subnets : v.subnets.ids])
+  subnet_ids = (local.ec2) ? flatten([for v in module.get-subnets : v.subnets.ids]) : null
   template = file(
     var.template == "" ? format("%s/ecs.tpl", path.module) : var.template,
   )
@@ -10,7 +10,7 @@ locals {
       var.security_group_ids,
     ),
   )
-  vpc_id = element(distinct([for v in module.get-subnets : v.vpc.id]), 0)
+  vpc_id = (local.ec2) ? element(distinct([for v in module.get-subnets : v.vpc.id]), 0) : null
 }
 
 resource "aws_ecs_cluster" "default" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,15 @@
-#output "rendered_template" {
-#  value = "${data.template_file.selected.0.rendered}"
-#}
-
-output "security_group_name" {
-  value = aws_security_group.default.*.name
-}
-
-output "security_group_id" {
-  value = aws_security_group.default.*.id
-}
-
 output "name" {
   value = aws_ecs_cluster.default.name
 }
 
 output "id" {
   value = aws_ecs_cluster.default.id
+}
+
+output "security_group_name" {
+  value = (local.ec2) ? aws_security_group.default.*.name : null
+}
+
+output "security_group_id" {
+  value = (local.ec2) ? aws_security_group.default.*.id : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,11 +47,6 @@ variable "key_name" {
   default     = ""
 }
 
-variable "vpc" {
-  description = "The name of the VPC to use"
-  default     = ""
-}
-
 variable "subnet_ids" {
   description = "A list of subnet ids to use for the container instances"
   type        = list(string)
@@ -102,4 +97,9 @@ variable "security_groups" {
   description = "A list of security group name(s) associated with the (EC2) container instances"
   type        = list(string)
   default     = []
+}
+
+variable "vpc" {
+  description = "The name of the VPC to use"
+  default     = null
 }


### PR DESCRIPTION
This module doesn't need vpc_id and subnet_id for Fargate-only clusters. Fix errors that ensue when invoked without those input variables, and clean up outputs that don't apply in this case.