### PR TITLE
Miscellaneous improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,33 @@ Provides an ECS cluster, and optionally EC2 container instances.
 Example Usage
 -----------------
 
-A Fargate cluster
+### Fargate cluster
 
 ```hcl
-module "service_name" {
+module "fargate-cluster" {
   source = "git@github.com:techservicesillinois/terraform-aws-ecs-cluster"
 
-  name = "identity"
-  enable_ec2_container_instances = false
+  name       = "fargate-example"
+  enable_ec2 = false
+}
+```
+### EC2 cluster
+
+```hcl
+module "ecs-cluster" {
+  source = "git@github.com:techservicesillinois/terraform-aws-ecs-cluster"
+  
+  name             = "ec2-example"
+  desired_capacity = 1
+  instance_type    = "t4g.small"
+  max_size         = 4
+  min_size         = 1
+
+
+  # Include security groups for each ALB forwarding to this cluster.
+  vpc                  = "my-vpc"
+  subnet_type          = "private"
+  security_group_names = ["my-vpc-alb-private", "my-vpc-alb-public"]
 }
 ```
 
@@ -23,73 +42,71 @@ Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Amazon ECS cluster to create.
+* `associate_public_ip_address` - (Optional) Associate a public IP
+  address with the ECS container instances. (The default is `true`).
 
-* `enable_ec2_container_instances` - (Optional) Set to false for
-  Fargate clusters. Default is true.
+* `desired_capacity` - (Optional) Desired number of EC2 instances.
+  Applies only to EC2 clusters.
+
+* `efs_volume_name` - (Optional) EFS volume name. Applies only to EC2 clusters.
+
+* `enable_ec2` - (Optional) Set to `false` to manage a Fargate cluster.
+Default is `true`, which means the cluster will consist of
+dedicated EC2 instances.
 
 * `iam_instance_profile` - (Optional) The IAM instance profile to
-   associate with the ECS container instances (default ecsInstanceRole).
-
-* `min` - (Optional) The minimum number of ECS container instances
-  (default 1).
-
-* `max` - (Optional) The maximum number of ECS container instances
-  (default 10).
-
-* `desired` - (Optional) The desired number ECS of container instances
-  (default 3).
-
-* `efs_volume_name` - (Optional) EFS volume name.
-
-* `associate_public_ip_address` - (Optional) Associate a public ip
-  address with the ECS container instances (default true).
-
-* `instance_type` - (Optional) The EC2 instance type to use for the
-  container instances (default t2.micro).
-
-* `key_name` - (Optional) Name of an AWS key pair to use for the
-  container instances.
-
-* `vpc` - (Optional) The name of the VPC to use.
-
-* `subnet_ids` - (Optional) A list of subnet ids to use for the
-  container instances.
-
-* `template` - (Optional) Template used to configure underlying EC2
-  instances.
-
-* `subnet_type` - (Optional) Subnet type (e.g., 'campus', 'private', 'public') for resource placement. Useful for EC2 clusters; not used for Fargate clusters.
-
-* `ssh_cidr_blocks` - (Optional) List of CIDR blocks to use for SSH
-  access.
-
-* `tags` - (Optional) A mapping of tags to assign to all resources
-  that support tagging.
+   associate with the ECS container instances. The default is
+   `ecsInstanceRole`). Applies only to EC2 clusters.
 
 * `ingress_security_group_ids` - (Optional) A list of security group
-  id(s) that can directly communicate with containers.
+  id(s) that can directly communicate with containers. Applies only to EC2 clusters.
 
-* `ingress_security_groups` - (Optional) A list of security group
-  name(s) that can directly communicate with containers.
+* `ingress_security_group_names` - (Optional) A list of security group
+  name(s) that can directly communicate with containers. Applies only to EC2 clusters.
 
-* `security_group_ids` - (Optional) A list of security group ID(s)
-  associated with the EC2 container instances.
+* `instance_type` - (Optional) The EC2 instance type to use for the
+  container instances. Applies only to EC2 clusters.
 
-* `security_groups` - (Optional) A list of security group name(s)
-  associated with the EC2 container instances.
+* `key_name` - (Optional) Name of an AWS key pair to use for the
+  container instances. Applies only to EC2 clusters.
+
+* `min_size` - (Optional) Minimum number of EC2 instances.
+  Applies only to EC2 clusters.
+
+* `max_size` - (Optional) Maximum number of EC2 instances.
+  Applies only to EC2 clusters.
+
+* `name` - (Required) The name of the Amazon ECS cluster to create.
+
+* `security_group_ids` - (Optional) A list of security group ID(s).
+Applies only to EC2 clusters.
+
+* `security_group_names` - (Optional) A list of security group name(s)
+  associated with the EC2 container instances. Applies only to EC2 clusters.
+
+* `ssh_cidr_blocks` - (Optional) List of CIDR blocks to use for SSH
+  access. Applies only to EC2 clusters.
+
+* `subnet_ids` - (Optional) A list of subnet ids to use for the
+  container instances. Applies only to EC2 clusters.
+
+* `subnet_type` - (Optional) Subnet type (e.g., 'campus', 'private', 'public') for resource placement. Applies only to EC2 clusters.
+
+* `tags` - (Optional) Tags to be applied to resources where supported.
+  
+* `template` - (Optional) Template used to configure underlying EC2
+  instances. Applies only to EC2 clusters.
+
+* `vpc` - (Optional) The name of the VPC in which to place the cluster.
+Applies only to EC2 clusters.
 
 Attributes Reference
 --------------------
 
 The following attributes are exported:
 
-* `security_group_name` - The name of the default security group
-for the EC2 container instances.
+* `id` - The Amazon Resource Name (ARN) of the cluster.
 
-* `security_group_id` - The ARN of the default security group for
-the EC2 container instances.
+* `name` - The cluster name.
 
-* `name` - The name that identifies the cluster
-
-* `id` - The Amazon Resource Name (ARN) that identifies the cluster
+* `security_groups` - A map whose keys are the security group name, and whose values are the corresponding security group ID. Applies only to EC2 clusters. 

--- a/data.tf
+++ b/data.tf
@@ -1,28 +1,26 @@
-# FIXME: Replace reference to branch with reference to tagged version.
-
 module "get-subnets" {
   source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.4"
 
-  count = local.ec2 ? 1 : 0
+  count = var.enable_ec2 ? 1 : 0
 
   subnet_type = var.subnet_type
   vpc         = var.vpc
 }
 
 data "aws_security_group" "ingress" {
-  count = local.ec2 ? length(var.ingress_security_groups) : 0
+  count = var.enable_ec2 ? length(var.ingress_security_group_names) : 0
 
-  name = var.ingress_security_groups[count.index]
+  name = var.ingress_security_group_names[count.index]
 }
 
 data "aws_security_group" "selected" {
-  count = local.ec2 ? length(var.security_groups) : 0
+  count = var.enable_ec2 ? length(var.security_group_names) : 0
 
-  name = var.security_groups[count.index]
+  name = var.security_group_names[count.index]
 }
 
 data "aws_ami" "selected" {
-  count = local.ec2 ? 1 : 0
+  count = var.enable_ec2 ? 1 : 0
 
   most_recent = true
 
@@ -35,7 +33,7 @@ data "aws_ami" "selected" {
 }
 
 data "template_file" "selected" {
-  count = local.ec2 ? 1 : 0
+  count = var.enable_ec2 ? 1 : 0
 
   template = local.template
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,11 @@
+output "arn" {
+  value = aws_ecs_cluster.default.arn
+}
+
 output "name" {
   value = aws_ecs_cluster.default.name
 }
 
-output "id" {
-  value = aws_ecs_cluster.default.id
-}
-
-output "security_group_name" {
-  value = (local.ec2) ? aws_security_group.default.*.name : null
-}
-
-output "security_group_id" {
-  value = (local.ec2) ? aws_security_group.default.*.id : null
+output "security_groups" {
+  value = { for sg in aws_security_group.default : (sg.name) => sg.id }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,20 @@
-variable "name" {
-  description = "The name of the Amazon ECS cluster to create"
+variable "associate_public_ip_address" {
+  description = "Associate a public ip address with the ECS container instances"
+  default     = true
 }
 
-variable "enable_ec2_container_instances" {
-  description = "Set to false for Fargate only clusters."
+variable "desired_capacity" {
+  description = "Desired number of EC2 instances"
+  default     = null
+}
+
+variable "efs_volume_name" {
+  description = "Optional EFS volume name"
+  default     = null
+}
+
+variable "enable_ec2" {
+  description = "Use EC2 cluster; set to false for a Fargate cluster"
   default     = true
 }
 
@@ -12,79 +23,40 @@ variable "iam_instance_profile" {
   default     = "ecsInstanceRole"
 }
 
-variable "min" {
-  description = "The minimum number of ECS container instances"
-  default     = 1
-}
-
-variable "max" {
-  description = "The maximum number of container instances"
-  default     = 10
-}
-
-variable "desired" {
-  description = "The desired number of container instances"
-  default     = 3
-}
-
-variable "efs_volume_name" {
-  description = "Optional EFS volume name"
-  default     = ""
-}
-
-variable "associate_public_ip_address" {
-  description = "Associate a public ip address with the ECS container instances"
-  default     = true
-}
-
-variable "instance_type" {
-  description = "The EC2 instance type to use for the container instances"
-  default     = "t2.micro"
-}
-
-variable "key_name" {
-  description = "Name of an AWS key pair to use for the container instances"
-  default     = ""
-}
-
-variable "subnet_ids" {
-  description = "A list of subnet ids to use for the container instances"
-  type        = list(string)
-  default     = []
-}
-
-variable "template" {
-  description = "Template used to configure underlying EC2 instances"
-  default     = ""
-}
-
-variable "subnet_type" {
-  description = "Subnet type (e.g., 'campus', 'private', 'public') for resource placement"
-  default     = ""
-}
-
-variable "ssh_cidr_blocks" {
-  description = "List of CIDR blocks to use for SSH access"
-  type        = list(string)
-  default     = []
-}
-
-variable "tags" {
-  description = "Map of tags for resources where supported"
-  type        = map(string)
-  default     = {}
-}
-
 variable "ingress_security_group_ids" {
   description = "A list of security group id(s) that can directly communicate with containers"
   type        = list(string)
   default     = []
 }
 
-variable "ingress_security_groups" {
+variable "ingress_security_group_names" {
   description = "A list of security group name(s) that can directly communicate with containers"
   type        = list(string)
   default     = []
+}
+
+variable "instance_type" {
+  description = "The EC2 instance type to use for the container instances"
+  default     = null
+}
+
+variable "key_name" {
+  description = "Name of an AWS key pair to use for the container instances"
+  default     = null
+}
+
+variable "min_size" {
+  description = "Minimum number of EC2 instances"
+  default     = null
+}
+
+variable "max_size" {
+  description = "Maximum number of EC2 instances"
+  default     = null
+}
+
+variable "name" {
+  description = "The name of the Amazon ECS cluster to create"
 }
 
 variable "security_group_ids" {
@@ -93,10 +65,39 @@ variable "security_group_ids" {
   default     = []
 }
 
-variable "security_groups" {
+variable "security_group_names" {
   description = "A list of security group name(s) associated with the (EC2) container instances"
   type        = list(string)
   default     = []
+}
+
+
+variable "ssh_cidr_blocks" {
+  description = "List of CIDR blocks to use for SSH access"
+  type        = list(string)
+  default     = []
+}
+
+variable "subnet_ids" {
+  description = "A list of subnet ids to use for the container instances"
+  type        = list(string)
+  default     = []
+}
+
+variable "subnet_type" {
+  description = "Subnet type (e.g., 'campus', 'private', 'public') for resource placement"
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to be applied to resources where supported"
+  type        = map(string)
+  default     = {}
+}
+
+variable "template" {
+  description = "Template used to configure underlying EC2 instances"
+  default     = null
 }
 
 variable "vpc" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.4"
 }


### PR DESCRIPTION
*   Improve resource naming.
    
*   Improve tagging behavior.
    
*   Make some variables less verbose, and make them better track underlying Terraform argument names.
    
*   Eliminate wired-in default variables that are grossly out of date, like using the legacy t2.small instance type. Some variables simply impose defaults that may not be sensible for all use cases. When building an ECS cluster, it's not unreasonable to expect the infrastructure manager to be aware of sensible input variable values.
    
*   Improve documentation.
