### PR TITLE
Add support for container insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,30 @@ Applies only to EC2 clusters.
 * `vpc` - (Optional) The name of the VPC in which to place the cluster.
 Applies only to EC2 clusters.
 
+`setting`
+-------
+
+A `setting` block is a list of maps, each map containing a name and value pair
+describing cluster settings to be applied. The `setting` block is optional.
+
+Currently, only one setting is supported.
+
+* `name` - (Required) The setting name.
+
+* `value` – (Optional) The setting value corresponding to `name`.
+
+Currently, the only value allowed for `name` is `containerInsights`. The
+corresponding `value` in the map must be either `enabled` or `disabled`.
+
+```
+  setting = [
+    {
+      name  = "containerInsights"
+      value = "enabled"
+    }
+  ]
+```
+
 Attributes Reference
 --------------------
 
@@ -110,3 +134,5 @@ The following attributes are exported:
 * `name` - The cluster name.
 
 * `security_groups` - A map whose keys are the security group name, and whose values are the corresponding security group ID. Applies only to EC2 clusters. 
+
+* `setting` – A map containing each of the defined `setting` name/value pairs.

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,14 @@ locals {
 resource "aws_ecs_cluster" "default" {
   name = var.name
   tags = merge({ Name = var.name }, var.tags)
+
+  dynamic "setting" {
+    for_each = { for s in var.setting : s.name => s.value }
+    content {
+      name  = setting.key
+      value = setting.value
+    }
+  }
 }
 
 resource "aws_autoscaling_group" "default" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "name" {
 output "security_groups" {
   value = { for sg in aws_security_group.default : (sg.name) => sg.id }
 }
+
+output "setting" {
+  value = { for s in var.setting : s.name => s.value }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -71,6 +71,19 @@ variable "security_group_names" {
   default     = []
 }
 
+variable "setting" {
+  description = "List of cluster settings"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+
+  validation {
+    condition     = try(contains(["containerInsights"], var.setting.name), true)
+    error_message = "The 'setting' value is not one of the valid values 'containerInsights'."
+  }
+}
 
 variable "ssh_cidr_blocks" {
   description = "List of CIDR blocks to use for SSH access"


### PR DESCRIPTION
We want to use container insights to get more advanced metrics from CloudWatch. This requires adding support for the `setting` block to define cluster settings.

Currently, `containerInsights` is the only setting supported. The valid values for this setting are `enabled` and `disabled`.

Update documentation to add new variable and new output.